### PR TITLE
Enable Travis CI build automation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: java

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/GoClipse/goclipse.png?branch=master)](https://travis-ci.org/GoClipse/goclipse)
+
 See [About](documentation/About.md) for user information.
 
 ## Developers Guide


### PR DESCRIPTION
Enables Travis CI for automated builds.

This patch enables builds to automatically test building on oraclejdk7 (default) as well as adds a Travis CI build status badge to the README file.

Some additional steps need to be completed in order to enable Travis CI on this repository:
http://about.travis-ci.org/docs/user/getting-started/

Example builds: https://travis-ci.org/zxiiro/goclipse
