### PR TITLE
Fix go oracle errors when project root is not GOPATH.

### DIFF
--- a/plugin_ide.core/src/com/googlecode/goclipse/core/GoProjectEnvironment.java
+++ b/plugin_ide.core/src/com/googlecode/goclipse/core/GoProjectEnvironment.java
@@ -67,9 +67,9 @@ public class GoProjectEnvironment implements GoEnvironmentConstants {
 			return rawGoPath;
 		}
 		
-		// Implicitly add project location to GOPATH
-		ArrayList2<String> newGoPathEntries = new ArrayList2<>(projectLoc.toPathString());
-		newGoPathEntries.addAll(rawGoPath.getGoPathEntries());
+		// Implicitly add project location to the end of GOPATH
+		ArrayList2<String> newGoPathEntries = new ArrayList2<>(rawGoPath.getGoPathEntries());
+		newGoPathEntries.add(projectLoc.toPathString());
 		return new GoPath(newGoPathEntries);
 	}
 	


### PR DESCRIPTION
Previously, the project root was being added to the beginning of GOPATH, and jump to definition would error out with errors like:

    Error executing `Open definition (go oracle)`.
    Could not determine Go package for Go file (/home/alex/myproject/mygopath/src/alex/file.go),
   file not in the Go environment.

With GOPATH set to /home/alex/myproject/mygopath
and the project root at /home/alex/myproject

This is because the project root was being implicitly added before the other GOPATH changes, and
GoPath.java::findGoPackageForLocation(Location goPackageLocation) would find the implicit path
first, and try to resolve the package name against '/home/alex/myproject/src' instead of
'/home/alex/myproject/mygopath/src'.